### PR TITLE
Potential fix for code scanning alert no. 108: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
   build:
     needs: tagging
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Limit permissions to read-only access to repository contents
     steps:
       # Step 1: Checkout the repository code
       - name: Checkout ${{ github.repository }}


### PR DESCRIPTION
Potential fix for [https://github.com/tschm/cradle/security/code-scanning/108](https://github.com/tschm/cradle/security/code-scanning/108)

To fix the issue, we will add a `permissions` block to the `build` job in the workflow. This block will explicitly set the permissions to `contents: read`, which is the minimum required for the job to check out the repository and perform its tasks. This change ensures that the `build` job does not inherit unnecessary permissions from the repository or workflow defaults.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
